### PR TITLE
Fix Compile errors reported in #16

### DIFF
--- a/Sample/Sample/LibrarySpec.swift
+++ b/Sample/Sample/LibrarySpec.swift
@@ -18,7 +18,7 @@ class LibrarySpec : SleipnirSpec {
         }
         
         it("should not be nil") {
-            object.shouldNot.beNil()
+            expect(object).toNot(beNil());
         }
     }
     

--- a/Sleipnir/Sleipnir/Matchers/ShouldSyntax.swift
+++ b/Sleipnir/Sleipnir/Matchers/ShouldSyntax.swift
@@ -24,7 +24,7 @@ public extension NSObject {
     }
 }
 
-public extension Array {
+extension Array {
     
     var should: ArrayMatch<T, NSArray> { return ArrayMatch(value: self, positive: true) }
     var shouldNot: ArrayMatch<T, NSArray> { return ArrayMatch(value: self, positive: false) }
@@ -38,7 +38,7 @@ public extension String {
     
 }
 
-public extension Optional  {
+extension Optional  {
     
     var should: OptionalMatch { return OptionalMatch(value: self, positive: true) }
     var shouldNot: OptionalMatch { return OptionalMatch(value: self, positive: false) }


### PR DESCRIPTION
Public extensions of generic classes are apparently not supported
in the version of Swift in XCode 6.1. So for now I've made them
internal so others can at least compile.

I can't run the tests because of #17. I'll submit another pull
request with a new test runner.
